### PR TITLE
Convert to Swift 3

### DIFF
--- a/Promise.xcodeproj/project.pbxproj
+++ b/Promise.xcodeproj/project.pbxproj
@@ -173,13 +173,15 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				TargetAttributes = {
 					3454F9CD1D4FACD000985BBF = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					3454F9D71D4FACD000985BBF = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -269,8 +271,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -318,8 +322,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -361,6 +367,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -378,6 +385,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.khanlou.Promise;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -388,6 +397,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.khanlou.PromiseTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -398,6 +408,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.khanlou.PromiseTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Promise/Promise+Extras.swift
+++ b/Promise/Promise+Extras.swift
@@ -24,11 +24,10 @@ extension Promise {
         })
     }
 
+    /// - parameter delay: In seconds
     static func delay(_ delay: TimeInterval) -> Promise<()> {
         return Promise<()>(work: { fulfill, reject in
-            let nanoseconds = Int64(delay*Double(NSEC_PER_SEC))
-            let time = DispatchTime.now() + Double(nanoseconds) / Double(NSEC_PER_SEC)
-            DispatchQueue.main.asyncAfter(deadline: time, execute: {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: {
                 fulfill(())
             })
         })
@@ -56,7 +55,7 @@ extension Promise {
     }
 
     @discardableResult
-    func always(on queue: DispatchQueue, _ onComplete: @escaping () -> Void) -> Promise<Value> {
+    func always(on queue: DispatchQueue, _ onComplete: @escaping () -> ()) -> Promise<Value> {
         return then(on: queue, { _ in
             onComplete()
         }, { _ in
@@ -65,7 +64,7 @@ extension Promise {
     }
 
     @discardableResult
-    func always(_ onComplete: @escaping () -> Void) -> Promise<Value> {
+    func always(_ onComplete: @escaping () -> ()) -> Promise<Value> {
         return always(on: DispatchQueue.main, onComplete)
     }
 

--- a/PromiseTests/PromiseAllTests.swift
+++ b/PromiseTests/PromiseAllTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class PromiseAllTests: XCTestCase {
     func testAll() {
-        weak var expectation = expectationWithDescription("`Promise.all` should wait until multiple promises are fulfilled before returning.")
+        weak var expectation = self.expectation(description: "`Promise.all` should wait until multiple promises are fulfilled before returning.")
         
         let promise1 = Promise(value: 1)
         let promise2 = Promise<Int>(work: { fulfill, reject in
@@ -36,14 +36,14 @@ class PromiseAllTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         guard let array = final.value else { XCTFail(); return }
         XCTAssertEqual(array, [1, 2, 3, 4])
         XCTAssert(final.isFulfilled)
     }
     
     func testAllWithPreFulfilledValues() {
-        weak var expectation = expectationWithDescription("`Promise.all` should wait until multiple promises are fulfilled before returning.")
+        weak var expectation = self.expectation(description: "`Promise.all` should wait until multiple promises are fulfilled before returning.")
         
         let promise1 = Promise(value: 1)
         let promise2 = Promise(value: 2)
@@ -55,28 +55,28 @@ class PromiseAllTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         guard let array = final.value else { XCTFail(); return }
         XCTAssertEqual(array, [1, 2, 3])
         XCTAssert(final.isFulfilled)
     }
     
     func testAllWithEmptyArray() {
-        weak var expectation = expectationWithDescription("`Promise.all` should wait until multiple promises are fulfilled before returning.")
+        weak var expectation = self.expectation(description: "`Promise.all` should wait until multiple promises are fulfilled before returning.")
         
         
         let final: Promise<[Int]> = Promise<Int>.all([])
         final.always({
             expectation?.fulfill()
         })
-        waitForExpectationsWithTimeout(10, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
         guard let array = final.value else { XCTFail(); return }
         XCTAssertEqual(array, [])
         XCTAssert(final.isFulfilled)
     }
     
     func testAllWithRejectionHappeningFirst() {
-        weak var expectation = expectationWithDescription("`Promise.all` should wait until multiple promises are fulfilled before returning.")
+        weak var expectation = self.expectation(description: "`Promise.all` should wait until multiple promises are fulfilled before returning.")
         
         let promise1 = Promise<Int>(work: { fulfill, reject in
             delay(0.1) {
@@ -107,13 +107,13 @@ class PromiseAllTests: XCTestCase {
             XCTFail()
         })
         
-        waitForExpectationsWithTimeout(10, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
         XCTAssertNotNil(final.error)
         XCTAssert(final.isRejected)
     }
     
     func testAllWithRejectionHappeningLast() {
-        weak var expectation = expectationWithDescription("`Promise.all` should wait until multiple promises are fulfilled before returning.")
+        weak var expectation = self.expectation(description: "`Promise.all` should wait until multiple promises are fulfilled before returning.")
         
         let promise1 = Promise<Int>(work: { fulfill, reject in
             delay(0.05) {
@@ -144,7 +144,7 @@ class PromiseAllTests: XCTestCase {
             XCTFail()
         })
         
-        waitForExpectationsWithTimeout(10, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
         XCTAssertNotNil(final.error)
         XCTAssert(final.isRejected)
     }

--- a/PromiseTests/PromiseAlwaysTests.swift
+++ b/PromiseTests/PromiseAlwaysTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class PromiseAlwaysTests: XCTestCase {
     
     func testAlways() {
-        weak var expectation = expectationWithDescription("`Promise.always` should always fire when the promise is fulfilled.")
+        weak var expectation = self.expectation(description: "`Promise.always` should always fire when the promise is fulfilled.")
         
         let promise = Promise<Int>(work: { fulfill, reject in
             delay(0.5) {
@@ -24,12 +24,12 @@ class PromiseAlwaysTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isFulfilled)
     }
     
     func testAlwaysRejects() {
-        weak var expectation = expectationWithDescription("`Promise.always` should always fire when the promise is rejected.")
+        weak var expectation = self.expectation(description: "`Promise.always` should always fire when the promise is rejected.")
         
         let promise = Promise<Int>(work: { fulfill, reject in
             delay(0.5) {
@@ -41,12 +41,12 @@ class PromiseAlwaysTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isRejected)
     }
     
     func testAlwaysInstantFulfill() {
-        weak var expectation = expectationWithDescription("`Promise.always` should always fire when the promise is rejected.")
+        weak var expectation = self.expectation(description: "`Promise.always` should always fire when the promise is rejected.")
         
         let promise = Promise(value: 5)
         
@@ -54,12 +54,12 @@ class PromiseAlwaysTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isFulfilled)
     }
     
     func testAlwaysInstantReject() {
-        weak var expectation = expectationWithDescription("`Promise.always` should always fire when the promise is rejected.")
+        weak var expectation = self.expectation(description: "`Promise.always` should always fire when the promise is rejected.")
         
         let promise = Promise<Int>(error: SimpleError())
         
@@ -67,7 +67,7 @@ class PromiseAlwaysTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isRejected)
     }
 

--- a/PromiseTests/PromiseDelayTests.swift
+++ b/PromiseTests/PromiseDelayTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class PromiseDelayTests: XCTestCase {
     func testDelay() {
-        weak var expectation = expectationWithDescription("`Promise.delay` should succeed after the given time period has elapsed.")
+        weak var expectation = self.expectation(description: "`Promise.delay` should succeed after the given time period has elapsed.")
         
         let goodPromise = Promise<()>.delay(0.2)
         let badPromise = Promise<()>.delay(1.1)
@@ -22,13 +22,13 @@ class PromiseDelayTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(goodPromise.isFulfilled)
         XCTAssert(badPromise.isPending)
     }
     
     func testTimeoutPromise() {
-        weak var expectation = expectationWithDescription("`Promise.timeout` should succeed after the given time period has elapsed.")
+        weak var expectation = self.expectation(description: "`Promise.timeout` should succeed after the given time period has elapsed.")
         
         let goodPromise: Promise<()> = Promise<()>.timeout(0.2)
         let badPromise: Promise<()> = Promise<()>.timeout(1.1)
@@ -39,13 +39,13 @@ class PromiseDelayTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(goodPromise.isRejected)
         XCTAssert(badPromise.isPending)
     }
     
     func testTimeoutFunctionSucceeds() {
-        weak var expectation = expectationWithDescription("`Promise.timeout` should succeed after the given time period has elapsed.")
+        weak var expectation = self.expectation(description: "`Promise.timeout` should succeed after the given time period has elapsed.")
         
         let promise = Promise<Int>(work: { fulfill, reject in
             delay(0.01) {
@@ -59,13 +59,13 @@ class PromiseDelayTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isFulfilled)
     }
 
     
     func testTimeoutFunctionFails() {
-        weak var expectation = expectationWithDescription("`Promise.timeout` should succeed after the given time period has elapsed.")
+        weak var expectation = self.expectation(description: "`Promise.timeout` should succeed after the given time period has elapsed.")
         
         let promise = Promise<Int>(work: { fulfill, reject in
             delay(1) {
@@ -79,7 +79,7 @@ class PromiseDelayTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isRejected)
     }
 }

--- a/PromiseTests/PromiseRaceTests.swift
+++ b/PromiseTests/PromiseRaceTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class PromiseRaceTests: XCTestCase {
     
     func testRace() {
-        weak var expectation = expectationWithDescription("`Promise.race` should fulfill as soon as the first promise is fulfilled.")
+        weak var expectation = self.expectation(description: "`Promise.race` should fulfill as soon as the first promise is fulfilled.")
         
         let promise1 = Promise<Int>(work: { fulfill, reject in
             delay(0.1) {
@@ -36,14 +36,14 @@ class PromiseRaceTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         guard let int = final.value else { XCTFail(); return }
         XCTAssertEqual(int, 2)
         XCTAssert(final.isFulfilled)
     }
     
     func testRaceFailure() {
-        weak var expectation = expectationWithDescription("`Promise.race` should reject as soon as the first promise is reject.")
+        weak var expectation = self.expectation(description: "`Promise.race` should reject as soon as the first promise is reject.")
         
         let promise1 = Promise<Int>(work: { fulfill, reject in
             delay(0.05) {
@@ -58,12 +58,12 @@ class PromiseRaceTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(final.isRejected)
     }
     
     func testInstantResolve() {
-        weak var expectation = expectationWithDescription("`Promise.race` should reject as soon as the first promise is reject.")
+        weak var expectation = self.expectation(description: "`Promise.race` should reject as soon as the first promise is reject.")
         
         let promise1 = Promise<Int>(value: 1)
         let promise2 = Promise<()>.delay(0.1).then({ 5 })
@@ -74,13 +74,13 @@ class PromiseRaceTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(final.isFulfilled)
         XCTAssertEqual(final.value, 1)
     }
     
     func testInstantReject() {
-        weak var expectation = expectationWithDescription("`Promise.race` should reject as soon as the first promise is reject.")
+        weak var expectation = self.expectation(description: "`Promise.race` should reject as soon as the first promise is reject.")
         
         let promise1 = Promise<Int>(error: SimpleError())
         let promise2 = Promise<()>.delay(0.1).then({ 5 })
@@ -91,7 +91,7 @@ class PromiseRaceTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(final.isRejected)
     }
 

--- a/PromiseTests/PromiseRecoverTests.swift
+++ b/PromiseTests/PromiseRecoverTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class PromiseRecoverTests: XCTestCase {
     func testRecover() {
-        weak var expectation = expectationWithDescription("`Promise.recover` should recover from errors.")
+        weak var expectation = self.expectation(description: "`Promise.recover` should recover from errors.")
         
         let promise = Promise<Int>(work: { fulfill, reject in
             delay(0.1) {
@@ -26,14 +26,14 @@ class PromiseRecoverTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         guard let int = promise.value else { XCTFail(); return }
         XCTAssertEqual(int, 5)
         XCTAssert(promise.isFulfilled)
     }
     
     func testRecoverInstant() {
-        weak var expectation = expectationWithDescription("`Promise.recover` should recover if the initial promise is rejected.")
+        weak var expectation = self.expectation(description: "`Promise.recover` should recover if the initial promise is rejected.")
         
         let promise = Promise<Int>(error: SimpleError()).recover({ error in
             XCTAssert(error as? SimpleError == SimpleError())
@@ -44,14 +44,14 @@ class PromiseRecoverTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         guard let int = promise.value else { XCTFail(); return }
         XCTAssertEqual(int, 5)
         XCTAssert(promise.isFulfilled)
     }
     
     func testIgnoreRecover() {
-        weak var expectation = expectationWithDescription("`Promise.recover` shouldn't recover if the initial promise is fulfilled.")
+        weak var expectation = self.expectation(description: "`Promise.recover` shouldn't recover if the initial promise is fulfilled.")
         
         let promise = Promise<Int>(work: { fulfill, reject in
             delay(0.1) {
@@ -66,14 +66,14 @@ class PromiseRecoverTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         guard let int = promise.value else { XCTFail(); return }
         XCTAssertEqual(int, 2)
         XCTAssert(promise.isFulfilled)
     }
     
     func testIgnoreRecoverInstant() {
-        weak var expectation = expectationWithDescription("`Promise.recover` shouldn't recover if the initial promise is fulfilled.")
+        weak var expectation = self.expectation(description: "`Promise.recover` shouldn't recover if the initial promise is fulfilled.")
         
         let promise = Promise(value: 2).recover({ error in
             XCTAssert(error as? SimpleError == SimpleError())
@@ -84,7 +84,7 @@ class PromiseRecoverTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         guard let int = promise.value else { XCTFail(); return }
         XCTAssertEqual(int, 2)
         XCTAssert(promise.isFulfilled)

--- a/PromiseTests/PromiseRetryTests.swift
+++ b/PromiseTests/PromiseRetryTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class PromiseRetryTests: XCTestCase {
     func testRetry() {
-        weak var expectation = expectationWithDescription("`Promise.retry` should retry and eventually succeed.")
+        weak var expectation = self.expectation(description: "`Promise.retry` should retry and eventually succeed.")
         
         var currentCount = 3
         let promise = Promise<Int>.retry(count: 3, delay: 0, generate: { () -> Promise<Int> in
@@ -24,13 +24,13 @@ class PromiseRetryTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertEqual(promise.value, 8)
         XCTAssert(promise.isFulfilled)
     }
     
     func testRetryWithInstantSuccess() {
-        weak var expectation = expectationWithDescription("`Promise.retry` should never retry if it succeeds immediately.")
+        weak var expectation = self.expectation(description: "`Promise.retry` should never retry if it succeeds immediately.")
         
         var currentCount = 1
         let promise = Promise<Int>.retry(count: 3, delay: 0, generate: { () -> Promise<Int> in
@@ -43,13 +43,13 @@ class PromiseRetryTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertEqual(promise.value, 8)
         XCTAssert(promise.isFulfilled)
     }
     
     func testRetryWithNeverSuccess() {
-        weak var expectation = expectationWithDescription("`Promise.retry` should never retry if it succeeds immediately.")
+        weak var expectation = self.expectation(description: "`Promise.retry` should never retry if it succeeds immediately.")
         
         let promise = Promise<Int>.retry(count: 3, delay: 0, generate: { () -> Promise<Int> in
             return Promise(error: SimpleError())
@@ -57,7 +57,7 @@ class PromiseRetryTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isRejected)
     }
 }

--- a/PromiseTests/PromiseTests.swift
+++ b/PromiseTests/PromiseTests.swift
@@ -10,9 +10,9 @@ import XCTest
 @testable import Promise
 
 class PromiseTests: XCTestCase {
+
     func testThen() {
-        
-        weak var expectation = expectationWithDescription("The then function should be called twice.")
+        weak var expectation = self.expectation(description: "The then function should be called twice.")
         var count = 0
         
         let promise = Promise(value: 5).then({ _ in
@@ -22,13 +22,13 @@ class PromiseTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(count == 2)
         XCTAssert(promise.isFulfilled)
     }
     
     func testAsync() {
-        weak var expectation = expectationWithDescription("The `work:` based constructor of Promise should work correctly.")
+        weak var expectation = self.expectation(description: "The `work:` based constructor of Promise should work correctly.")
         Promise<String>(work: { (fulfill, reject) in
             delay(0.05) {
                 fulfill("hey")
@@ -37,11 +37,11 @@ class PromiseTests: XCTestCase {
             XCTAssertEqual(string, "hey")
             expectation?.fulfill()
         })
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testAsyncRejection() {
-        weak var expectation = expectationWithDescription("Calling `reject` from the `work:` constructor should cause the Promise to be rejceted.")
+        weak var expectation = self.expectation(description: "Calling `reject` from the `work:` constructor should cause the Promise to be rejceted.")
         let promise = Promise<String>(work: { (fulfill, reject) in
             delay(0.05) {
                 reject(SimpleError())
@@ -57,13 +57,13 @@ class PromiseTests: XCTestCase {
         }).onFailure({ error in
             expectation?.fulfill()
         })
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertNotNil(promise.error)
         XCTAssert(promise.isRejected)
     }
     
     func testThenWhenPending() {
-        weak var expectation = expectationWithDescription("Pending Promises shouldn't call their `then` callbacks.")
+        weak var expectation = self.expectation(description: "Pending Promises shouldn't call their `then` callbacks.")
         
         var thenCalled = false
         
@@ -74,12 +74,12 @@ class PromiseTests: XCTestCase {
         delay(0.05) {
             expectation?.fulfill()
         }
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertFalse(thenCalled)
     }
     
     func testRejectedAfterFulfilled() {
-        weak var expectation = expectationWithDescription("A Promise that is rejected after being fulfilled should not call any further `then` callbacks.")
+        weak var expectation = self.expectation(description: "A Promise that is rejected after being fulfilled should not call any further `then` callbacks.")
         
         var thenCalled = false
         
@@ -96,7 +96,7 @@ class PromiseTests: XCTestCase {
         delay(0.05) {
             expectation?.fulfill()
         }
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertTrue(thenCalled)
         XCTAssert(promise.isRejected)
     }
@@ -108,7 +108,7 @@ class PromiseTests: XCTestCase {
     }
     
     func testFulfilled() {
-        weak var expectation = expectationWithDescription("A Promise that has `fulfill` called on it should be fulfilled with the value passed to `fullfill`.")
+        weak var expectation = self.expectation(description: "A Promise that has `fulfill` called on it should be fulfilled with the value passed to `fullfill`.")
         
         let promise = Promise<Int>()
         
@@ -121,13 +121,13 @@ class PromiseTests: XCTestCase {
         delay(0.05) {
             expectation?.fulfill()
         }
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertTrue(promise.value == 10)
         XCTAssert(promise.isFulfilled)
     }
     
     func testRejected() {
-        weak var expectation = expectationWithDescription("A Promise that is rejected should have its `onFailure` method called.")
+        weak var expectation = self.expectation(description: "A Promise that is rejected should have its `onFailure` method called.")
         
         let error = SimpleError()
         let promise = Promise<Int>()
@@ -138,13 +138,13 @@ class PromiseTests: XCTestCase {
         
         promise.reject(error)
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertEqual(promise.error as? SimpleError, error)
         XCTAssert(promise.isRejected)
     }
     
     func testMap() {
-        weak var expectation = expectationWithDescription("")
+        weak var expectation = self.expectation(description: "")
         
         let promise = Promise(value: "someString").then({ string in
             return string.characters.count
@@ -155,13 +155,13 @@ class PromiseTests: XCTestCase {
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertEqual(promise.value, 20)
         XCTAssert(promise.isFulfilled)
     }
     
     func testFlatMap() {
-        weak var expectation = expectationWithDescription("A `then` callback that returns another Promise should execute and fulfill the next Promise.")
+        weak var expectation = self.expectation(description: "A `then` callback that returns another Promise should execute and fulfill the next Promise.")
         let promise = Promise<String>(work: { fulfill, reject in
             delay(0.05) {
                 fulfill("hello")
@@ -178,13 +178,13 @@ class PromiseTests: XCTestCase {
         })
         
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertEqual(promise.value, 5)
         XCTAssert(promise.isFulfilled)
     }
         
     func testTrailingClosuresCompile() {
-        weak var expectation = expectationWithDescription("`Promise.all` should wait until multiple promises are fulfilled before returning.")
+        weak var expectation = self.expectation(description: "`Promise.all` should wait until multiple promises are fulfilled before returning.")
         
         let promise = Promise<String> { fulfill, reject in
             delay(0.05) {
@@ -204,7 +204,7 @@ class PromiseTests: XCTestCase {
             expectation?.fulfill()
         }
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         XCTAssertEqual(promise.value, 6)
         XCTAssert(promise.isFulfilled)
     }

--- a/PromiseTests/PromiseZipTests.swift
+++ b/PromiseTests/PromiseZipTests.swift
@@ -13,16 +13,16 @@ import Foundation
 
 class PromiseZipTests: XCTestCase {
     func testZipping2() {
-        weak var expectation = expectationWithDescription("`Promise.zip` should be type safe.")
+        weak var expectation = self.expectation(description: "`Promise.zip` should be type safe.")
         
         let promise = Promise(value: 2)
         let promise2 = Promise(value: "some string")
-        let zipped = Promise<()>.zip(promise, second: promise2)
+        let zipped = Promise<()>.zip(promise, and: promise2)
         zipped.always({
             expectation?.fulfill()
         })
         
-        waitForExpectationsWithTimeout(1, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
         guard let tuple = zipped.value else { XCTFail(); return }
         XCTAssertEqual(tuple.0, 2)
         XCTAssertEqual(tuple.1, "some string")

--- a/PromiseTests/delay.swift
+++ b/PromiseTests/delay.swift
@@ -8,15 +8,15 @@
 
 import XCTest
 
-internal func delay(duration: NSTimeInterval, block: () -> ()) {
-    let time = dispatch_time(DISPATCH_TIME_NOW, Int64(duration*Double(NSEC_PER_SEC)))
-    dispatch_after(time, dispatch_get_main_queue(), {
+internal func delay(_ duration: TimeInterval, block: @escaping () -> ()) {
+    let time = DispatchTime.now() + Double(Int64(duration*Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
+    DispatchQueue.main.asyncAfter(deadline: time, execute: {
         block()
     })
 }
 
 
-struct SimpleError: ErrorType, Equatable {
+struct SimpleError: Error, Equatable {
     
 }
 

--- a/PromiseTests/delay.swift
+++ b/PromiseTests/delay.swift
@@ -9,8 +9,7 @@
 import XCTest
 
 internal func delay(_ duration: TimeInterval, block: @escaping () -> ()) {
-    let time = DispatchTime.now() + Double(Int64(duration*Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
-    DispatchQueue.main.asyncAfter(deadline: time, execute: {
+    DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: {
         block()
     })
 }


### PR DESCRIPTION
Using Xcode 8.0 GM seed (8A218a)

Swift 3 changes:
- Swift 3 API changes (especially with Dispatch)
- Change capitalization of enum cases
- Add `@discardableResult` to methods that need it
- Add `@escaping` to closure parameters
- Rename args for `zip()`, to be more like the Swift 3 API design guidelines (I think)

Xcode 8 changes:
- Let Xcode do suggested build setting updates

Not strictly Swift 3-related:
- Tweak some headerdocs, and split State into extensions
