### PR TITLE
Handle throws

### DIFF
--- a/Promise.xcodeproj/project.pbxproj
+++ b/Promise.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1A2A8CFE1D5D764600421E3E /* PromiseRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2A8CFD1D5D764600421E3E /* PromiseRetryTests.swift */; };
 		1AE9F56F1D526F8A00185453 /* Promise+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE9F56E1D526F8A00185453 /* Promise+Extras.swift */; };
 		1AF54F3B1D67D60000557CCB /* PromiseZipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF54F3A1D67D60000557CCB /* PromiseZipTests.swift */; };
+		1AFA1FA01D8A0C9500E4F76E /* PromiseThrowsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFA1F9F1D8A0C9500E4F76E /* PromiseThrowsTests.swift */; };
 		1AFF80FA1D5166C000C55D5A /* delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFF80F91D5166C000C55D5A /* delay.swift */; };
 		1AFF80FC1D51676700C55D5A /* PromiseAllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFF80FB1D51676700C55D5A /* PromiseAllTests.swift */; };
 		3454F9D21D4FACD000985BBF /* Promise.h in Headers */ = {isa = PBXBuildFile; fileRef = 3454F9D11D4FACD000985BBF /* Promise.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -40,6 +41,7 @@
 		1A2A8CFD1D5D764600421E3E /* PromiseRetryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseRetryTests.swift; sourceTree = "<group>"; };
 		1AE9F56E1D526F8A00185453 /* Promise+Extras.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Promise+Extras.swift"; sourceTree = "<group>"; };
 		1AF54F3A1D67D60000557CCB /* PromiseZipTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseZipTests.swift; sourceTree = "<group>"; };
+		1AFA1F9F1D8A0C9500E4F76E /* PromiseThrowsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseThrowsTests.swift; sourceTree = "<group>"; };
 		1AFF80F91D5166C000C55D5A /* delay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = delay.swift; sourceTree = "<group>"; };
 		1AFF80FB1D51676700C55D5A /* PromiseAllTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseAllTests.swift; sourceTree = "<group>"; };
 		3454F9CE1D4FACD000985BBF /* Promise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Promise.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -112,6 +114,7 @@
 				1A2A8CFB1D5D743100421E3E /* PromiseRecoverTests.swift */,
 				1A2A8CFD1D5D764600421E3E /* PromiseRetryTests.swift */,
 				1AF54F3A1D67D60000557CCB /* PromiseZipTests.swift */,
+				1AFA1F9F1D8A0C9500E4F76E /* PromiseThrowsTests.swift */,
 			);
 			path = PromiseTests;
 			sourceTree = "<group>";
@@ -236,6 +239,7 @@
 				1A2A8CFA1D5D717D00421E3E /* PromiseAlwaysTests.swift in Sources */,
 				1A2A8CFE1D5D764600421E3E /* PromiseRetryTests.swift in Sources */,
 				1A2A8CF81D5D58A800421E3E /* PromiseRaceTests.swift in Sources */,
+				1AFA1FA01D8A0C9500E4F76E /* PromiseThrowsTests.swift in Sources */,
 				1AF54F3B1D67D60000557CCB /* PromiseZipTests.swift in Sources */,
 				1AFF80FA1D5166C000C55D5A /* delay.swift in Sources */,
 				1AFF80FC1D51676700C55D5A /* PromiseAllTests.swift in Sources */,

--- a/Promise/Promise.swift
+++ b/Promise/Promise.swift
@@ -108,13 +108,17 @@ final class Promise<Value> {
         })
     }
     
-    func then<NewValue>(on queue: dispatch_queue_t = dispatch_get_main_queue(), _ onFulfilled: ((Value) -> Promise<NewValue>)) -> Promise<NewValue> {
+    func then<NewValue>(on queue: dispatch_queue_t = dispatch_get_main_queue(), _ onFulfilled: ((Value) throws -> Promise<NewValue>)) -> Promise<NewValue> {
         //this one is flatmap
         return Promise<NewValue>(work: { fulfill, reject in
             self.addCallbacks(
                 on: queue,
                 onFulfilled: { value in
-                    onFulfilled(value).then(fulfill, reject)
+                    do {
+                        try onFulfilled(value).then(fulfill, reject)
+                    } catch let error {
+                        reject(error)
+                    }
                 },
                 onRejected: reject
             )

--- a/Promise/Promise.swift
+++ b/Promise/Promise.swift
@@ -121,10 +121,14 @@ final class Promise<Value> {
         })
     }
     
-    func then<NewValue>(on queue: dispatch_queue_t = dispatch_get_main_queue(), _ onFulfilled: ((Value) -> NewValue)) -> Promise<NewValue> {
+    func then<NewValue>(on queue: dispatch_queue_t = dispatch_get_main_queue(), _ onFulfilled: ((Value) throws -> NewValue)) -> Promise<NewValue> {
         //this one is map
         return then(on: queue, { (value) -> Promise<NewValue> in
-            return Promise<NewValue>(value: onFulfilled(value))
+            do {
+                return Promise<NewValue>(value: try onFulfilled(value))
+            } catch let error {
+                return Promise<NewValue>(error: error)
+            }
         })
     }
     

--- a/PromiseTests/PromiseThrowsTests.swift
+++ b/PromiseTests/PromiseThrowsTests.swift
@@ -42,5 +42,37 @@ class PromiseThrowsTests: XCTestCase {
         waitForExpectationsWithTimeout(1, handler: nil)
         XCTAssert(promise.error is SimpleError)
     }
+    
+    func testThrowsInFlatmapping() {
+        weak var expectation = expectationWithDescription("`Promise.zip` should be type safe.")
+        
+        let promise = Promise(value: 2).then({ (value: Int) -> Promise<Int> in
+            if value == 3 {
+                throw SimpleError()
+            }
+            return Promise(value: 5)
+        }).always({
+            expectation?.fulfill()
+        })
+        
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertEqual(promise.value, 5)
+    }
+    
+    func testThrowsInFlatmappingWithError() {
+        weak var expectation = expectationWithDescription("`Promise.zip` should be type safe.")
+        
+        let promise = Promise(value: 2).then({ (value: Int) -> Promise<Int> in
+            if value == 2 {
+                throw SimpleError()
+            }
+            return Promise(value: 5)
+        }).always({
+            expectation?.fulfill()
+        })
+        
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssert(promise.error is SimpleError)
+    }
 
 }

--- a/PromiseTests/PromiseThrowsTests.swift
+++ b/PromiseTests/PromiseThrowsTests.swift
@@ -1,0 +1,46 @@
+//
+//  PromiseThrowsTests.swift
+//  Promise
+//
+//  Created by Soroush Khanlou on 9/14/16.
+//
+//
+
+import XCTest
+@testable import Promise
+
+class PromiseThrowsTests: XCTestCase {
+
+    func testThrowsInMapping() {
+        weak var expectation = expectationWithDescription("`Promise.zip` should be type safe.")
+        
+        let promise = Promise(value: 2).then({ (value: Int) -> Int in
+            if value == 3 {
+                throw SimpleError()
+            }
+            return 5
+        }).always({
+            expectation?.fulfill()
+        })
+        
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssertEqual(promise.value, 5)
+    }
+    
+    func testThrowsInMappingWithError() {
+        weak var expectation = expectationWithDescription("`Promise.zip` should be type safe.")
+        
+        let promise = Promise(value: 2).then({ (value: Int) -> Int in
+            if value == 2 {
+                throw SimpleError()
+            }
+            return 5
+        }).always({
+            expectation?.fulfill()
+        })
+        
+        waitForExpectationsWithTimeout(1, handler: nil)
+        XCTAssert(promise.error is SimpleError)
+    }
+
+}


### PR DESCRIPTION
This pull request adds the ability to throw within `then` functions.

@kelan Should I wait on your PRs to merge this one?
