### PR TITLE
Add `always` method.

### DIFF
--- a/Promise/Promise.swift
+++ b/Promise/Promise.swift
@@ -174,6 +174,11 @@ public final class Promise<Value> {
         return then(on: queue, { _ in }, onRejected)
     }
     
+    @discardableResult
+    public func always(on queue: DispatchQueue = .main, _ onComplete: @escaping () -> ()) -> Promise<Value> {
+        return then(on: queue, { _ in onComplete() }, { _ in onComplete() })
+    }
+    
     public func reject(_ error: Error) {
         updateState(.rejected(error: error))
     }


### PR DESCRIPTION
Used for cases where you need to perform the same work whether the promise succeeds or fails.