### PR TITLE
Zip arities

### DIFF
--- a/Promise.playground/Pages/Zip Functions Generator.xcplaygroundpage/Contents.swift
+++ b/Promise.playground/Pages/Zip Functions Generator.xcplaygroundpage/Contents.swift
@@ -1,0 +1,56 @@
+//: [Previous](@previous)
+
+/*:
+
+ # Zip Functions Generator
+
+ This page generates `zip` functions for 3-*N* parameters. They all build on the
+ two parameter variant, with `zip` for *N* parameters always delegating work
+ to one with *N*-1 parameters.
+
+ */
+
+import Foundation
+
+func types(_ n: Int) -> String {
+    return (1...n).map { "T\($0)" }.joined(separator: ", ")
+}
+
+
+func createZip(_ n: Int) -> String {
+    var output: String = "/// Zips \(n) promises of different types into a single Promise whose\n"
+    output.append("/// type is a tuple of \(n) elements.\n")
+    output.append("public static func zip<")
+    output.append(types(n))
+    output.append(">(")
+    output.append((1...n-1).map { "_ p\($0): Promise<T\($0)>, " }.joined())
+    output.append("_ last: Promise<T\(n)>) -> Promise<(\(types(n)))> {\n")
+
+    output.append("return Promise<(\(types(n)))>(work: { (fulfill: @escaping ((\(types(n)))) -> Void, reject: @escaping (Error) -> Void) in\n")
+
+    output.append("let zipped: Promise<(\(types(n-1)))> = zip(")
+    output.append((1...n-1).map { "p\($0)" }.joined(separator: ", "))
+    output.append(")\n\n")
+
+    output.append("func resolver() -> Void {\n")
+    output.append("if let zippedValue = zipped.value, let lastValue = last.value {\n")
+    output.append("fulfill((")
+    output.append((0...n-2).map { "zippedValue.\($0), " }.joined())
+    output.append("lastValue))\n}\n}\n")
+
+    output.append("zipped.then({ _ in resolver() }, reject)\n")
+    output.append("last.then({ _ in resolver() }, reject)\n")
+
+    output.append("})\n}")
+
+    return output
+}
+
+func createZips(_ n: Int) -> String {
+    return (3...n).map(createZip).joined(separator: "\n\n")
+}
+
+print(createZips(6))
+
+
+//: [Next](@next)

--- a/Promise.playground/contents.xcplayground
+++ b/Promise.playground/contents.xcplayground
@@ -3,5 +3,6 @@
     <pages>
         <page name='Basic Usage'/>
         <page name='Common Patterns'/>
+        <page name='Zip Functions Generator'/>
     </pages>
 </playground>

--- a/Promise/Promise+Extras.swift
+++ b/Promise/Promise+Extras.swift
@@ -123,4 +123,40 @@ public enum Promises {
             second.then(resolver, reject)
         })
     }
+
+    // The following zip functions have been created with the 
+    // "Zip Functions Generator" playground page. If you need variants with
+    // more parameters, use it to generate them.
+
+    /// Zips 3 promises of different types into a single Promise whose
+    /// type is a tuple of 3 elements.
+    public static func zip<T1, T2, T3>(_ p1: Promise<T1>, _ p2: Promise<T2>, _ last: Promise<T3>) -> Promise<(T1, T2, T3)> {
+        return Promise<(T1, T2, T3)>(work: { (fulfill: @escaping ((T1, T2, T3)) -> Void, reject: @escaping (Error) -> Void) in
+            let zipped: Promise<(T1, T2)> = zip(p1, p2)
+
+            func resolver() -> Void {
+                if let zippedValue = zipped.value, let lastValue = last.value {
+                    fulfill((zippedValue.0, zippedValue.1, lastValue))
+                }
+            }
+            zipped.then({ _ in resolver() }, reject)
+            last.then({ _ in resolver() }, reject)
+        })
+    }
+
+    /// Zips 4 promises of different types into a single Promise whose
+    /// type is a tuple of 4 elements.
+    public static func zip<T1, T2, T3, T4>(_ p1: Promise<T1>, _ p2: Promise<T2>, _ p3: Promise<T3>, _ last: Promise<T4>) -> Promise<(T1, T2, T3, T4)> {
+        return Promise<(T1, T2, T3, T4)>(work: { (fulfill: @escaping ((T1, T2, T3, T4)) -> Void, reject: @escaping (Error) -> Void) in
+            let zipped: Promise<(T1, T2, T3)> = zip(p1, p2, p3)
+
+            func resolver() -> Void {
+                if let zippedValue = zipped.value, let lastValue = last.value {
+                    fulfill((zippedValue.0, zippedValue.1, zippedValue.2, lastValue))
+                }
+            }
+            zipped.then({ _ in resolver() }, reject)
+            last.then({ _ in resolver() }, reject)
+        })
+    }
 }

--- a/Promise/Promise+Extras.swift
+++ b/Promise/Promise+Extras.swift
@@ -104,8 +104,15 @@ extension Promise {
             }).then(fulfill).catch(reject)
         })
     }
-        
+
+    @available(*, deprecated, message: "Use Promises.zip instead")
     public static func zip<T, U>(_ first: Promise<T>, and second: Promise<U>) -> Promise<(T, U)> {
+        return Promises.zip(first, second)
+    }
+}
+
+public enum Promises {
+    public static func zip<T, U>(_ first: Promise<T>, _ second: Promise<U>) -> Promise<(T, U)> {
         return Promise<(T, U)>(work: { fulfill, reject in
             let resolver: (Any) -> () = { _ in
                 if let firstValue = first.value, let secondValue = second.value {

--- a/PromiseTests/PromiseZipTests.swift
+++ b/PromiseTests/PromiseZipTests.swift
@@ -27,4 +27,27 @@ class PromiseZipTests: XCTestCase {
         XCTAssertEqual(tuple.0, 2)
         XCTAssertEqual(tuple.1, "some string")
     }
+
+    func testMultipleParameters() {
+        // The >2 parameter variants of zip are all generated, so testing one
+        // *should* mean all others work too.
+
+        weak var expectation = self.expectation(description: "`Promises.zip` should be type safe.")
+
+        let promise = Promise(value: 2)
+        let promise2 = Promise(value: "some string")
+        let promise3 = Promise(value: [1, 1, 2, 3, 5])
+        let promise4 = Promise(value: ["two", "strings"])
+        let zipped = Promises.zip(promise, promise2, promise3, promise4)
+        zipped.always({
+            expectation?.fulfill()
+        })
+
+        waitForExpectations(timeout: 1, handler: nil)
+        guard let tuple = zipped.value else { XCTFail(); return }
+        XCTAssertEqual(tuple.0, 2)
+        XCTAssertEqual(tuple.1, "some string")
+        XCTAssertEqual(tuple.2, [1, 1, 2, 3, 5])
+        XCTAssertEqual(tuple.3, ["two", "strings"])
+    }
 }

--- a/PromiseTests/PromiseZipTests.swift
+++ b/PromiseTests/PromiseZipTests.swift
@@ -13,11 +13,11 @@ import Promise
 
 class PromiseZipTests: XCTestCase {
     func testZipping2() {
-        weak var expectation = self.expectation(description: "`Promise.zip` should be type safe.")
-        
+        weak var expectation = self.expectation(description: "`Promises.zip` should be type safe.")
+
         let promise = Promise(value: 2)
         let promise2 = Promise(value: "some string")
-        let zipped = Promise<()>.zip(promise, and: promise2)
+        let zipped = Promises.zip(promise, promise2)
         zipped.always({
             expectation?.fulfill()
         })


### PR DESCRIPTION
As discussed in khanlou/Promise#14, I implemented >2-ary variants of `zip`.

- I first moved `zip` to a `Promises` enum and removed the `and` name from the second parameter.
- I made the old location call the new one, and marked the old one as deprecated.
- I added a playground page for generating the multiple-parameter variants.

  I ran into a swiftc crasher while working on this. I originally tried to do a similar `resolver` function as you have inside the original `zip` function, but swiftc 3.0.2 segfaulted with it in my generated versions. After I changed `resolver` so it takes no parameters, swiftc stopped crashing.

  I added some explicit types to the functions, because I thought they might help with compilation speed and it wasn't much of a hassle as the code was autogenerated anyway, but I didn't measure it.

- I arbitrarily picked six as the largest variant to add to the code. I have no opinion as to what number would make sense.
