### PR TITLE
No longer creating additional promise in tap version of then

### DIFF
--- a/Promise/Promise.swift
+++ b/Promise/Promise.swift
@@ -185,19 +185,7 @@ public final class Promise<Value> {
     
     @discardableResult
     public func then(on queue: ExecutionContext = DispatchQueue.main, _ onFulfilled: @escaping (Value) -> (), _ onRejected: @escaping (Error) -> () = { _ in }) -> Promise<Value> {
-        _ = Promise<Value>(work: { fulfill, reject in
-            self.addCallbacks(
-                on: queue,
-                onFulfilled: { value in
-                    fulfill(value)
-                    onFulfilled(value)
-                },
-                onRejected: { error in
-                    reject(error)
-                    onRejected(error)
-                }
-            )
-        })
+        addCallbacks(on: queue, onFulfilled: onFulfilled, onRejected: onRejected)
         return self
     }
     


### PR DESCRIPTION
Removed promise in `tap` version of `then` following conversation in #28 

> Test Suite 'All tests' passed at 2017-11-15 17:01:02.906.
> 	 Executed 58 tests, with 0 failures (0 unexpected) in 3.459 (3.535) seconds
