### PR TITLE
Fixes missing queue argument

### DIFF
--- a/Promise/Promise.swift
+++ b/Promise/Promise.swift
@@ -164,7 +164,7 @@ public final class Promise<Value> {
                 on: queue,
                 onFulfilled: { value in
                     do {
-                        try onFulfilled(value).then(fulfill, reject)
+                        try onFulfilled(value).then(on: queue, fulfill, reject)
                     } catch let error {
                         reject(error)
                     }


### PR DESCRIPTION
Spurious main thread dispatch in this cascading function.
Context: I’m trying to use this inside of kitura where async dispatches to the main thread are somehow completely blocked so that the promise never resolves.