### PR TITLE
spm cl error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "Promises",
+    name: "Promise",
     products: [
       .library(
         name: "Promise",
@@ -15,6 +15,11 @@ let package = Package(
         name: "Promise",
         dependencies: [],
         path: "Promise"
+      ),
+      .testTarget(
+        name: "PromiseTests", 
+        dependencies: ["Promise"]
       )
+
     ]
 )


### PR DESCRIPTION
Error probably from package name in package.swift not being the same as the repo.

error: invalid target name at 'PromiseTests'; name of non-test targets cannot end in 'Tests'

Added the test target.