### PR TITLE
Testing with SPM while on Linux

### DIFF
--- a/LinuxMain.swift
+++ b/LinuxMain.swift
@@ -1,0 +1,6 @@
+import XCTest
+@testable import PromiseTests
+
+XCTMain([
+    // testCase(WhateverTestCase.allTests)
+])

--- a/LinuxMain.swift
+++ b/LinuxMain.swift
@@ -2,5 +2,16 @@ import XCTest
 @testable import PromiseTests
 
 XCTMain([
-    testCase(ExecutionContextTests.allTests)
+    testCase(ExecutionContextTests.allTests),
+    testCase(PromiseAllTests.allTests),
+    testCase(PromiseAlwaysTests.allTests),
+    testCase(PromiseDelayTests.allTests),
+    testCase(PromiseEnsureTests.allTests),
+    testCase(PromiseKickoffTests.allTests),
+    testCase(PromiseRaceTests.allTests),
+    testCase(PromiseRecoverTests.allTests),
+    testCase(PromiseRetryTests.allTests),
+    testCase(PromiseTests.allTests),
+    testCase(PromiseThrowsTests.allTests),
+    testCase(PromiseZipTests.allTests),
 ])

--- a/LinuxMain.swift
+++ b/LinuxMain.swift
@@ -2,5 +2,5 @@ import XCTest
 @testable import PromiseTests
 
 XCTMain([
-    // testCase(WhateverTestCase.allTests)
+    testCase(ExecutionContextTests.allTests)
 ])

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "Promise",
+    name: "Promises",
     products: [
       .library(
         name: "Promise",

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "Promises",
+    name: "Promise",
     products: [
       .library(
         name: "Promise",
@@ -15,6 +15,11 @@ let package = Package(
         name: "Promise",
         dependencies: [],
         path: "Promise"
+      ),
+      .testTarget(
+        name: "PromiseTests", 
+        dependencies: ["Promise"]
       )
+
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,23 +4,22 @@ import PackageDescription
 let package = Package(
     name: "Promises",
     products: [
-      .library(
-        name: "Promise",
-        targets: ["Promise"]
-      ),
+        .library(
+            name: "Promise",
+            targets: ["Promise"]
+        ),
     ],
     dependencies: [],
     targets: [
-      .target(
-        name: "Promise",
-        dependencies: [],
-        path: "Promise"
-      ),
-      .testTarget(
-        name: "PromiseTests", 
-        dependencies: ["Promise"],
-        path: "PromiseTests"
-      )
-
+        .target(
+            name: "Promise",
+            dependencies: [],
+            path: "Promise"
+        ),
+        .testTarget(
+            name: "PromiseTests",
+            dependencies: ["Promise"],
+            path: "PromiseTests"
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
       ),
       .testTarget(
         name: "PromiseTests", 
-        dependencies: ["Promise"]
+        dependencies: ["Promise"],
+        path: "PromiseTests"
       )
 
     ]

--- a/PromiseTests/ExecutionContextTests.swift
+++ b/PromiseTests/ExecutionContextTests.swift
@@ -98,4 +98,11 @@ class ExecutionContextTests: XCTestCase {
         
     }
 
+
+    static let allTests = [
+        ("testNonInvalidatedInvalidatableQueue", testNonInvalidatedInvalidatableQueue),
+        ("testInvalidatedInvalidatableQueue", testInvalidatedInvalidatableQueue),
+        ("testTapContinuesToFireInvalidatableQueue", testTapContinuesToFireInvalidatableQueue),
+        ("testInvalidatableQueueSupportsNonMainQueues", testInvalidatableQueueSupportsNonMainQueues),
+    ]
 }

--- a/PromiseTests/ExecutionContextTests.swift
+++ b/PromiseTests/ExecutionContextTests.swift
@@ -9,10 +9,7 @@
 import XCTest
 
 import Promise
-
-#if os(Linux)
-    import Dispatch
-#endif
+import Dispatch
 
 class ExecutionContextTests: XCTestCase {
 

--- a/PromiseTests/ExecutionContextTests.swift
+++ b/PromiseTests/ExecutionContextTests.swift
@@ -10,6 +10,10 @@ import XCTest
 
 import Promise
 
+#if os(Linux)
+    import Dispatch
+#endif
+
 class ExecutionContextTests: XCTestCase {
 
 

--- a/PromiseTests/PromiseAllTests.swift
+++ b/PromiseTests/PromiseAllTests.swift
@@ -149,5 +149,11 @@ class PromiseAllTests: XCTestCase {
         XCTAssert(final.isRejected)
     }
     
-
+    static let allTests = [
+        ("testAll", testAll),
+        ("testAllWithPreFulfilledValues", testAllWithPreFulfilledValues),
+        ("testAllWithEmptyArray", testAllWithEmptyArray),
+        ("testAllWithRejectionHappeningFirst", testAllWithRejectionHappeningFirst),
+        ("testAllWithRejectionHappeningLast", testAllWithRejectionHappeningLast),
+    ]
 }

--- a/PromiseTests/PromiseAlwaysTests.swift
+++ b/PromiseTests/PromiseAlwaysTests.swift
@@ -20,9 +20,9 @@ class PromiseAlwaysTests: XCTestCase {
             }
         })
         
-        promise.always({ _ in
+        promise.always {
             expectation?.fulfill()
-        })
+        }
         
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isFulfilled)
@@ -37,9 +37,9 @@ class PromiseAlwaysTests: XCTestCase {
             }
         })
         
-        promise.always({ _ in
+        promise.always {
             expectation?.fulfill()
-        })
+        }
         
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isRejected)
@@ -50,9 +50,9 @@ class PromiseAlwaysTests: XCTestCase {
         
         let promise = Promise(value: 5)
         
-        promise.always({ _ in
+        promise.always {
             expectation?.fulfill()
-        })
+        }
         
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isFulfilled)
@@ -63,9 +63,9 @@ class PromiseAlwaysTests: XCTestCase {
         
         let promise = Promise<Int>(error: SimpleError())
         
-        promise.always({ _ in
+        promise.always {
             expectation?.fulfill()
-        })
+        }
         
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isRejected)

--- a/PromiseTests/PromiseAlwaysTests.swift
+++ b/PromiseTests/PromiseAlwaysTests.swift
@@ -71,4 +71,11 @@ class PromiseAlwaysTests: XCTestCase {
         XCTAssert(promise.isRejected)
     }
 
+
+    static let allTests = [
+        ("testAlways", testAlways),
+        ("testAlwaysRejects", testAlwaysRejects),
+        ("testAlwaysInstantFulfill", testAlwaysInstantFulfill),
+        ("testAlwaysInstantReject", testAlwaysInstantReject),
+    ]
 }

--- a/PromiseTests/PromiseAlwaysTests.swift
+++ b/PromiseTests/PromiseAlwaysTests.swift
@@ -20,9 +20,9 @@ class PromiseAlwaysTests: XCTestCase {
             }
         })
         
-        promise.always {
+        promise.always({
             expectation?.fulfill()
-        }
+        })
         
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isFulfilled)
@@ -37,9 +37,9 @@ class PromiseAlwaysTests: XCTestCase {
             }
         })
         
-        promise.always {
+        promise.always({
             expectation?.fulfill()
-        }
+        })
         
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isRejected)
@@ -50,9 +50,9 @@ class PromiseAlwaysTests: XCTestCase {
         
         let promise = Promise(value: 5)
         
-        promise.always {
+        promise.always({
             expectation?.fulfill()
-        }
+        })
         
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isFulfilled)
@@ -63,9 +63,9 @@ class PromiseAlwaysTests: XCTestCase {
         
         let promise = Promise<Int>(error: SimpleError())
         
-        promise.always {
+        promise.always({
             expectation?.fulfill()
-        }
+        })
         
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isRejected)

--- a/PromiseTests/PromiseDelayTests.swift
+++ b/PromiseTests/PromiseDelayTests.swift
@@ -82,4 +82,11 @@ class PromiseDelayTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isRejected)
     }
+
+    static let allTests = [
+        ("testDelay", testDelay),
+        ("testTimeoutPromise", testTimeoutPromise),
+        ("testTimeoutFunctionSucceeds", testTimeoutFunctionSucceeds),
+        ("testTimeoutFunctionFails", testTimeoutFunctionFails),
+    ]
 }

--- a/PromiseTests/PromiseEnsureTests.swift
+++ b/PromiseTests/PromiseEnsureTests.swift
@@ -51,4 +51,9 @@ class PromiseEnsureTests: XCTestCase {
         XCTAssertNotNil(promise.error)
     }
 
+    static let allTests = [
+        ("testEnsureRejects", testEnsureRejects),
+        ("testEnsureSucceeds", testEnsureSucceeds),
+        ("testEnsureOnlyCalledOnSucceess", testEnsureOnlyCalledOnSucceess),
+    ]
 }

--- a/PromiseTests/PromiseKickoffTests.swift
+++ b/PromiseTests/PromiseKickoffTests.swift
@@ -42,4 +42,8 @@ class PromiseKickoffTests: XCTestCase {
         XCTAssert(promise.isRejected)
     }
 
+    static let allTests = [
+        ("testKickoff", testKickoff),
+        ("testFailingKickoff", testFailingKickoff),
+    ]
 }

--- a/PromiseTests/PromiseRaceTests.swift
+++ b/PromiseTests/PromiseRaceTests.swift
@@ -95,4 +95,10 @@ class PromiseRaceTests: XCTestCase {
         XCTAssert(final.isRejected)
     }
 
+    static let allTests = [
+        ("testRace", testRace),
+        ("testRaceFailure", testRaceFailure),
+        ("testInstantResolve", testInstantResolve),
+        ("testInstantReject", testInstantReject),
+    ]
 }

--- a/PromiseTests/PromiseRecoverTests.swift
+++ b/PromiseTests/PromiseRecoverTests.swift
@@ -134,4 +134,13 @@ class PromiseRecoverTests: XCTestCase {
         XCTAssertEqual(int, 2)
         XCTAssert(promise.isFulfilled)
     }
+
+    static let allTests = [
+        ("testRecover", testRecover),
+        ("testRecoverWithThrowingFunction", testRecoverWithThrowingFunction),
+        ("testRecoverWithThrowingFunctionError", testRecoverWithThrowingFunctionError),
+        ("testRecoverInstant", testRecoverInstant),
+        ("testIgnoreRecover", testIgnoreRecover),
+        ("testIgnoreRecoverInstant", testIgnoreRecoverInstant),
+    ]
 }

--- a/PromiseTests/PromiseRetryTests.swift
+++ b/PromiseTests/PromiseRetryTests.swift
@@ -60,4 +60,10 @@ class PromiseRetryTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssert(promise.isRejected)
     }
+
+    static let allTests = [
+        ("testRetry", testRetry),
+        ("testRetryWithInstantSuccess", testRetryWithInstantSuccess),
+        ("testRetryWithNeverSuccess", testRetryWithNeverSuccess),
+    ]
 }

--- a/PromiseTests/PromiseTests.swift
+++ b/PromiseTests/PromiseTests.swift
@@ -263,4 +263,24 @@ class PromiseTests: XCTestCase {
         promise.reject(SimpleError())
         XCTAssertEqual(promise.value, "correct")
     }
+
+    static let allTests = [
+        ("testThen", testThen),
+        ("testAsync", testAsync),
+        ("testAsyncThrowing", testAsyncThrowing),
+        ("testAsyncRejection", testAsyncRejection),
+        ("testThenWhenPending", testThenWhenPending),
+        ("testRejectedAfterFulfilled", testRejectedAfterFulfilled),
+        ("testPending", testPending),
+        ("testFulfilled", testFulfilled),
+        ("testRejected", testRejected),
+        ("testMap", testMap),
+        ("testFlatMap", testFlatMap),
+        ("testTrailingClosuresCompile", testTrailingClosuresCompile),
+        ("testZalgoContained", testZalgoContained),
+        ("testDoubleResolve", testDoubleResolve),
+        ("testRejectThenResolve", testRejectThenResolve),
+        ("testDoubleReject", testDoubleReject),
+        ("testResolveThenReject", testResolveThenReject),
+    ]
 }

--- a/PromiseTests/PromiseThrowsTests.swift
+++ b/PromiseTests/PromiseThrowsTests.swift
@@ -75,4 +75,10 @@ class PromiseThrowsTests: XCTestCase {
         XCTAssert(promise.error is SimpleError)
     }
 
+    static let allTests = [
+        ("testThrowsInMapping", testThrowsInMapping),
+        ("testThrowsInMappingWithError", testThrowsInMappingWithError),
+        ("testThrowsInFlatmapping", testThrowsInFlatmapping),
+        ("testThrowsInFlatmappingWithError", testThrowsInFlatmappingWithError),
+    ]
 }

--- a/PromiseTests/PromiseZipTests.swift
+++ b/PromiseTests/PromiseZipTests.swift
@@ -50,4 +50,9 @@ class PromiseZipTests: XCTestCase {
         XCTAssertEqual(tuple.2, [1, 1, 2, 3, 5])
         XCTAssertEqual(tuple.3, ["two", "strings"])
     }
+
+    static let allTests = [
+        ("testZipping2", testZipping2),
+        ("testMultipleParameters", testMultipleParameters),
+    ]
 }

--- a/PromiseTests/delay.swift
+++ b/PromiseTests/delay.swift
@@ -7,6 +7,9 @@
 //
 
 import XCTest
+#if os(Linux)
+    import Dispatch
+#endif
 
 internal func delay(_ duration: TimeInterval, block: @escaping () -> ()) {
     DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: {

--- a/PromiseTests/delay.swift
+++ b/PromiseTests/delay.swift
@@ -7,9 +7,7 @@
 //
 
 import XCTest
-#if os(Linux)
-    import Dispatch
-#endif
+import Dispatch
 
 internal func delay(_ duration: TimeInterval, block: @escaping () -> ()) {
     DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: {


### PR DESCRIPTION
Configured SPM test target properly, based on #35 .
Changed package name back to "Promises" because there is no reason to change it.
Added LinuxMain.swift.
Added all tests to LinuxMain.

Tests compile and run on Swift.
Test support in Xcode is still intact, they work fine too, as they did before.
Resolves #37 , improves upon #35 .