### PR TITLE
Added travis configuration that is built as a generic-language.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl https://swift.org/builds/swift-4.0.3-release/ubuntu1404/swift-4.0.3-RELEASE/swift-4.0.3-RELEASE-ubuntu14.04.tar.gz -s | tar xz -C $SWIFT_DIR &> /dev/null ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install clang libicu-dev ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild -showsdks ; fi
 env:
   - SWIFT_VERSION=swift-4.0.3-RELEASE
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,26 @@
-language: objective-c
-osx_image: xcode8
-xcode_project: Promise.xcodeproj
-xcode_scheme: Promise
-xcode_sdk: iphonesimulator10.0
+language: generic
+matrix:
+   include:
+      - os: linux
+        dist: trusty
+        sudo: required
+      - os: osx
+        osx_image: xcode9.2
+addons:
+  apt:
+    packages:
+    - clang
+    - pkg-config
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then SWIFT_DIR=tests ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir $SWIFT_DIR ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl https://swift.org/builds/swift-4.0.3-release/ubuntu1404/swift-4.0.3-RELEASE/swift-4.0.3-RELEASE-ubuntu14.04.tar.gz -s | tar xz -C $SWIFT_DIR &> /dev/null ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install clang libicu-dev ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild -showsdks ; fi
+env:
+  - SWIFT_VERSION=swift-4.0.3-RELEASE
 script:
-  - set -o pipefail && xcodebuild -project Promise.xcodeproj -scheme Promise -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=10.0,name=iPhone SE' build test | xcpretty
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=$(pwd)/tests/$SWIFT_VERSION-ubuntu14.04/usr/bin:"${PATH}" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then swift test ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then xcodebuild clean test -scheme Promise -destination 'platform=iOS Simulator,name=iPhone SE,OS=latest' ; fi


### PR DESCRIPTION
Now the testing should work in case if SPM tests are configured properly.
Tests happen for iPhone simulator and in Linux SPM environment.
Conveniently resolves #36 .