### PR TITLE
Backward compatibility fix for compactMap

### DIFF
--- a/Promise/Promise+Extras.swift
+++ b/Promise/Promise+Extras.swift
@@ -22,11 +22,7 @@ public enum Promises {
             for promise in promises {
                 promise.then({ value in
                     if !promises.contains(where: { $0.isRejected || $0.isPending }) {
-                        #if swift(>=4.1)
-                            fulfill(promises.compactMap({ $0.value }))
-                        #else
-                            fulfill(promises.flatMap({ $0.value }))
-                        #endif
+                        fulfill(promises.compactMap({ $0.value }))
                     }
                 }).catch({ error in
                     reject(error)
@@ -174,3 +170,11 @@ extension Promise {
         })
     }
 }
+
+#if !swift(>=4.1)
+    internal extension Sequence {
+        func compactMap<T>(_ fn: (Element) throws -> T?) rethrows -> [T] {
+            return try flatMap { try fn($0).map { [$0] } ?? [] }
+        }
+    }
+#endif

--- a/Promise/Promise+Extras.swift
+++ b/Promise/Promise+Extras.swift
@@ -22,7 +22,11 @@ public enum Promises {
             for promise in promises {
                 promise.then({ value in
                     if !promises.contains(where: { $0.isRejected || $0.isPending }) {
-                        fulfill(promises.compactMap({ $0.value }))
+                        #if swift(>=4.1)
+                            fulfill(promises.compactMap({ $0.value }))
+                        #else
+                            fulfill(promises.flatMap({ $0.value }))
+                        #endif
                     }
                 }).catch({ error in
                     reject(error)


### PR DESCRIPTION
`flatMap` has been deprecated for use cases where the closure returns an optional value, `compactMap` should be used instead. Since `compactMap` only became available in Swift 4.1 this PR fixes backward compatibility of #43. Fixes #45.