### PR TITLE
Callback threading issues fixed #54

### DIFF
--- a/Promise.xcodeproj/xcshareddata/xcschemes/Promise watchOS.xcscheme
+++ b/Promise.xcodeproj/xcshareddata/xcschemes/Promise watchOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "EA55D57420D176610010074F"
-               BuildableName = "Promise_watchOS.framework"
+               BuildableName = "Promise.framework"
                BlueprintName = "Promise watchOS"
                ReferencedContainer = "container:Promise.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "EA55D57420D176610010074F"
-            BuildableName = "Promise_watchOS.framework"
+            BuildableName = "Promise.framework"
             BlueprintName = "Promise watchOS"
             ReferencedContainer = "container:Promise.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "EA55D57420D176610010074F"
-            BuildableName = "Promise_watchOS.framework"
+            BuildableName = "Promise.framework"
             BlueprintName = "Promise watchOS"
             ReferencedContainer = "container:Promise.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
This PR fixes an issue with threads & callback execution orders by using a DispatchGroup and a new queue property on the ExecitionContext. 