### PR TITLE
Modify the `then` that takes a void-returning closure take throwing closures (includes some breaking API changes)

### DIFF
--- a/Promise/Promise.swift
+++ b/Promise/Promise.swift
@@ -184,7 +184,7 @@ public final class Promise<Value> {
         return then(on: queue, { (value) -> Promise<NewValue> in
             do {
                 return Promise<NewValue>(value: try onFulfilled(value))
-            } catch let error {
+            } catch {
                 return Promise<NewValue>(error: error)
             }
         })

--- a/Promise/Promise.swift
+++ b/Promise/Promise.swift
@@ -154,7 +154,7 @@ public final class Promise<Value> {
         queue.async(execute: {
             do {
                 try work(self.fulfill, self.reject)
-            } catch let error {
+            } catch {
                 self.reject(error)
             }
         })
@@ -193,14 +193,17 @@ public final class Promise<Value> {
     @discardableResult
     public func then(on queue: ExecutionContext = DispatchQueue.main, _ onFulfilled: @escaping (Value) throws -> Void) -> Promise<Value> {
         return Promise(work: { (fulfill, reject) in
-            self.addCallbacks(on: queue, onFulfilled: { (value) in
-                do {
-                    try onFulfilled(value)
-                    fulfill(value)
-                } catch {
-                    reject(error)
-                }
-            }, onRejected: reject)
+            self.addCallbacks(
+                on: queue,
+                onFulfilled: { (value) in
+                    do {
+                        try onFulfilled(value)
+                        fulfill(value)
+                    } catch {
+                        reject(error)
+                    }
+                }, onRejected: reject
+            )
         })
     }
     

--- a/PromiseTests/ExecutionContextTests.swift
+++ b/PromiseTests/ExecutionContextTests.swift
@@ -90,7 +90,8 @@ class ExecutionContextTests: XCTestCase {
 
     func testTapContinuesToFireInvalidatableQueue() {
 
-        weak var expectation = self.expectation(description: "A tapping `then` block on an invalidated queue shouldn't prevent future then blocks from firing.")
+        weak var expectation = self.expectation(description: "A tapping `then` block on an invalidated queue shouldn't trigger future then blocks from firing.")
+        expectation?.isInverted = true
 
         let invalidatableQueue = InvalidatableQueue()
         invalidatableQueue.invalidate()

--- a/PromiseTests/ExecutionContextTests.swift
+++ b/PromiseTests/ExecutionContextTests.swift
@@ -88,7 +88,7 @@ class ExecutionContextTests: XCTestCase {
 
     }
 
-    func testTapContinuesToFireInvalidatableQueue() {
+    func testTapDoesNotFireAfterInvalidatableQueueIsInvalidated() {
 
         weak var expectation = self.expectation(description: "A tapping `then` block on an invalidated queue shouldn't trigger future then blocks from firing.")
         expectation?.isInverted = true
@@ -138,7 +138,7 @@ class ExecutionContextTests: XCTestCase {
         ("testConcurrency", testConcurrency),
         ("testNonInvalidatedInvalidatableQueue", testNonInvalidatedInvalidatableQueue),
         ("testInvalidatedInvalidatableQueue", testInvalidatedInvalidatableQueue),
-        ("testTapContinuesToFireInvalidatableQueue", testTapContinuesToFireInvalidatableQueue),
+        ("testTapDoesNotFireAfterInvalidatableQueueIsInvalidated", testTapDoesNotFireAfterInvalidatableQueueIsInvalidated),
         ("testInvalidatableQueueSupportsNonMainQueues", testInvalidatableQueueSupportsNonMainQueues),
     ]
 }

--- a/PromiseTests/PromiseTests.swift
+++ b/PromiseTests/PromiseTests.swift
@@ -92,28 +92,30 @@ class PromiseTests: XCTestCase {
     }
     
     func testRejectedAfterFulfilled() {
-        weak var expectation = self.expectation(description: "A Promise that is rejected after being fulfilled should not call any further `then` callbacks.")
+        weak var expectation = self.expectation(description: "A child Promise that is rejected after being generated from a parent fulfilled Promise should not call any further `then` callbacks.")
         
         var thenCalled = false
         var thenCalledAgain = false
 
-        let promise = Promise(value: 5).then({ _ in
+        let fulfilledPromise = Promise(value: 5)
+        let rejectedPromise = fulfilledPromise.then({ _ in
             thenCalled = true
         })
         
-        promise.then({ _ in
+        rejectedPromise.then({ _ in
             thenCalledAgain = true
         })
         
-        promise.reject(SimpleError())
+        rejectedPromise.reject(SimpleError())
         
         delay(0.05) {
             expectation?.fulfill()
         }
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssertTrue(thenCalled)
-        XCTAssertTrue(thenCalledAgain)
-        XCTAssert(promise.isFulfilled)
+        XCTAssertFalse(thenCalledAgain)
+        XCTAssertTrue(fulfilledPromise.isFulfilled)
+        XCTAssertTrue(rejectedPromise.isRejected)
     }
     
     func testPending() {


### PR DESCRIPTION
Hi!
I've been integrating this promise library into our app at work (as a replacement for another library), but I've found myself wanting to be able to use `then` with a void closure that also throws, but behaves like the `then` that takes a non-throwing void closure (as the other promise library that we replaced with this one had something like that). I've come up with this set of changes that should allow for this, but it does change the public API and the behavior of promises returned by the void `then`, so it would probably need to be for a 3.0 version or something.

This changes the `then` that takes a void closure to behave a lot more like the ones that are renamed versions of map/flatMap, in that it returns a brand new promise, instead of adding some callbacks and returning `self`. This feels to me to be a bit more internally consistent, since it's confusing to me that the behavior of which callbacks happen when can differ depending on the `then` overload I'm using. The `then` overload that takes in a fulfill and reject block was made internal and its default onRejected argument value was removed, so that people won't be able to mistakenly use the old differing behavior that might lead to confusion, and so that it wouldn't cause any ambiguity errors.

I've edited the two tests that failed as a result of this change so that they reflect this new behavior. There's some examples in the README that still need to be updated, but I wanted to see what you thought about this change in general first before I edit any docs or playground examples.

Thanks!