### PR TITLE
Error matchers

### DIFF
--- a/Promise.xcodeproj/project.pbxproj
+++ b/Promise.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		3454F9D21D4FACD000985BBF /* Promise.h in Headers */ = {isa = PBXBuildFile; fileRef = 3454F9D11D4FACD000985BBF /* Promise.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3454F9D91D4FACD000985BBF /* Promise.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3454F9CE1D4FACD000985BBF /* Promise.framework */; };
 		3454F9DE1D4FACD000985BBF /* PromiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3454F9DD1D4FACD000985BBF /* PromiseTests.swift */; };
+		34C947A02218B4C9009D1611 /* PromiseErrorMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C9479F2218B4C9009D1611 /* PromiseErrorMatcherTests.swift */; };
 		72B61D3C1E00E5830008E829 /* Wrench.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B61D3B1E00E5830008E829 /* Wrench.swift */; };
 		EA55D56E20D0C4930010074F /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6297331F803A59003973D5 /* Promise.swift */; };
 		EA55D56F20D0C4930010074F /* Promise+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6297341F803A59003973D5 /* Promise+Extras.swift */; };
@@ -64,6 +65,7 @@
 		3454F9D81D4FACD000985BBF /* PromiseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PromiseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3454F9DD1D4FACD000985BBF /* PromiseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseTests.swift; sourceTree = "<group>"; };
 		3454F9DF1D4FACD000985BBF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		34C9479F2218B4C9009D1611 /* PromiseErrorMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseErrorMatcherTests.swift; sourceTree = "<group>"; };
 		72B61D3B1E00E5830008E829 /* Wrench.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wrench.swift; sourceTree = "<group>"; };
 		76E25E381D8483D0000A58DF /* Promise.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Promise.playground; sourceTree = "<group>"; };
 		EA55D56620D0C44D0010074F /* Promise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Promise.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -160,6 +162,7 @@
 				72B61D3B1E00E5830008E829 /* Wrench.swift */,
 				1A0073671E2865CC00EB319A /* ExecutionContextTests.swift */,
 				1A42330B1F6ECC250045B066 /* PromiseKickoffTests.swift */,
+				34C9479F2218B4C9009D1611 /* PromiseErrorMatcherTests.swift */,
 			);
 			path = PromiseTests;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 				1A2A8CF81D5D58A800421E3E /* PromiseRaceTests.swift in Sources */,
 				1AFA1FA01D8A0C9500E4F76E /* PromiseThrowsTests.swift in Sources */,
 				1AF54F3B1D67D60000557CCB /* PromiseZipTests.swift in Sources */,
+				34C947A02218B4C9009D1611 /* PromiseErrorMatcherTests.swift in Sources */,
 				72B61D3C1E00E5830008E829 /* Wrench.swift in Sources */,
 				1AFF80FA1D5166C000C55D5A /* delay.swift in Sources */,
 				1AFF80FC1D51676700C55D5A /* PromiseAllTests.swift in Sources */,

--- a/Promise/Promise+Extras.swift
+++ b/Promise/Promise+Extras.swift
@@ -169,6 +169,14 @@ extension Promise {
             return value
         })
     }
+    
+    public func `catch`<E: Error>(type errorType: E.Type, _ onRejected: @escaping (E) -> Void) -> Promise<Value> {
+        return self.catch({ error in
+            if let castedError = error as? E {
+                onRejected(castedError)
+            }
+        })
+    }
 }
 
 #if !swift(>=4.1)

--- a/PromiseTests/PromiseErrorMatcherTests.swift
+++ b/PromiseTests/PromiseErrorMatcherTests.swift
@@ -1,0 +1,60 @@
+//
+//  PromiseErrorMatcherTests.swift
+//  PromiseTests
+//
+//  Created by Soroush Khanlou on 2/16/19.
+//
+
+import XCTest
+import Promise
+
+
+class PromiseErrorMatcherTests: XCTestCase {
+    
+    func testCasting() {
+        weak var expectation = self.expectation(description: "`Promise.catch` should always cast the error type.")
+        
+        var flag = false
+
+        Promise<Void>(error: WrenchError(message: "testing"))
+            .then({
+                XCTFail()
+            })
+            .catch(type: WrenchError.self, { wrenchError in
+                self.functionThatOnlyWorksWithWrenchErrors(wrenchError)
+                flag = true
+            })
+            .always({
+                expectation?.fulfill()
+            })
+        
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertTrue(flag)
+    }
+    
+    func testCastingFailing() {
+        weak var expectation = self.expectation(description: "`Promise.catch` should always cast the error type.")
+        
+        var flag = false
+        
+         Promise<Void>(error: SimpleError())
+            .catch({ error in
+                flag = !(error is WrenchError)
+            })
+            .catch(type: WrenchError.self, { wrenchError in
+                self.functionThatOnlyWorksWithWrenchErrors(wrenchError)
+                XCTFail()
+            })
+            .always({
+                expectation?.fulfill()
+            })
+        
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertTrue(flag)
+    }
+    
+    func functionThatOnlyWorksWithWrenchErrors(_ error: WrenchError) {
+        _ = 1 + 1
+    }
+    
+}

--- a/PromiseTests/PromiseErrorMatcherTests.swift
+++ b/PromiseTests/PromiseErrorMatcherTests.swift
@@ -11,8 +11,8 @@ import Promise
 
 class PromiseErrorMatcherTests: XCTestCase {
     
-    func testCasting() {
-        weak var expectation = self.expectation(description: "`Promise.catch` should always cast the error type.")
+    func testCastingExecutesMatchingErrors() {
+        weak var expectation = self.expectation(description: "`Promise.catch` should cast the error when it is the right type.")
         
         var flag = false
 
@@ -32,8 +32,8 @@ class PromiseErrorMatcherTests: XCTestCase {
         XCTAssertTrue(flag)
     }
     
-    func testCastingFailing() {
-        weak var expectation = self.expectation(description: "`Promise.catch` should always cast the error type.")
+    func testCastingIgnoresNonMatchingErrors() {
+        weak var expectation = self.expectation(description: "`Promise.catch` should not cast the error when it is the wrong type.")
         
         var flag = false
         
@@ -57,4 +57,9 @@ class PromiseErrorMatcherTests: XCTestCase {
         _ = 1 + 1
     }
     
+    static let allTests = [
+        ("testCastingIgnoresNonMatchingErrors", testCastingIgnoresNonMatchingErrors),
+        ("testCastingExecutesMatchingErrors", testCastingExecutesMatchingErrors),
+        ]
+
 }


### PR DESCRIPTION
This pull request adds the ability to "match" a specific type of error, and have the error you handle be casted to that type. I'm going to do the same thing with the PR as the last PR — leave it open for a week or two to see if anyone has any feedback. This PR is additive so this will go into the 2.1 release.

Wanted to thank @elenipapanik and @kremizask, the idea is pulled from their https://github.com/Workable/swift-error-handler.

One thing I'd be open to is adding an `ifNoMatch` parameter with an enum value of either `.ignore` or `.crash` where `.ignore` is the default.