### PR TITLE
Recovery by error type

### DIFF
--- a/PromiseTests/delay.swift
+++ b/PromiseTests/delay.swift
@@ -20,6 +20,9 @@ struct SimpleError: Error, Equatable {
     
 }
 
+struct AlternativeError: Error, Equatable {
+
+}
 
 func ==(lhs: SimpleError, rhs: SimpleError) -> Bool {
     return true


### PR DESCRIPTION
In #62 we discussed how to "filter" errors of a specific type, given the code exists to catch errors of a specific type (see #58).

With this PR I'm taking a stab at typed recovery, in order to allow a kind of branched recovery like this:

```swift
// When the underlying promise throws something other than `SimpleError`
// or `NetworkError`, the application quits with a `fatalError`.
generateStringPromise()
    .recover(type: SimpleError.self) { _ in return Promise(value: "move along, people") }
    .recover(type: NetworkError.self) { _ in return Promise(value: "nothing to see here") }
    .recover { error in fatalError("Unhandled: \(error)") }
    .then { value in print("Message: \(value)") }
```

What do you think, @khanlou?