### PR TITLE
Add some helper methods that are useful when dealing with errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Select Xcode
-      run: sudo xcode-select --switch /Applications/Xcode_10.3.app/Contents/Developer
+      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
     - name: Test
-      run: xcodebuild clean test -scheme "Promise" -destination 'platform=iOS Simulator,name=iPhone X,OS=12.4'
+      run: xcodebuild clean test -scheme "Promise" -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.2.2'
   linux:
     name: Linux
     runs-on: ubuntu-18.04

--- a/LinuxMain.swift
+++ b/LinuxMain.swift
@@ -14,4 +14,6 @@ XCTMain([
     testCase(PromiseTests.allTests),
     testCase(PromiseThrowsTests.allTests),
     testCase(PromiseZipTests.allTests),
+    testCase(PromiseErrorMatcherTests.allTests),
+    testCase(PromiseErrorTests.allTests),
 ])

--- a/Promise.xcodeproj/project.pbxproj
+++ b/Promise.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00C2D985238F100500C42EF9 /* PromiseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C2D984238F100500C42EF9 /* PromiseErrorTests.swift */; };
 		1A0073681E2865CC00EB319A /* ExecutionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0073671E2865CC00EB319A /* ExecutionContextTests.swift */; };
 		1A2A8CF61D5D36C500421E3E /* PromiseDelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2A8CF51D5D36C500421E3E /* PromiseDelayTests.swift */; };
 		1A2A8CF81D5D58A800421E3E /* PromiseRaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2A8CF71D5D58A800421E3E /* PromiseRaceTests.swift */; };
@@ -45,6 +46,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00C2D984238F100500C42EF9 /* PromiseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseErrorTests.swift; sourceTree = "<group>"; };
 		1A0073671E2865CC00EB319A /* ExecutionContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExecutionContextTests.swift; sourceTree = "<group>"; };
 		1A2A8CF51D5D36C500421E3E /* PromiseDelayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseDelayTests.swift; sourceTree = "<group>"; };
 		1A2A8CF71D5D58A800421E3E /* PromiseRaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseRaceTests.swift; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				1A0073671E2865CC00EB319A /* ExecutionContextTests.swift */,
 				1A42330B1F6ECC250045B066 /* PromiseKickoffTests.swift */,
 				34C9479F2218B4C9009D1611 /* PromiseErrorMatcherTests.swift */,
+				00C2D984238F100500C42EF9 /* PromiseErrorTests.swift */,
 			);
 			path = PromiseTests;
 			sourceTree = "<group>";
@@ -413,6 +416,7 @@
 				1A42330C1F6ECC250045B066 /* PromiseKickoffTests.swift in Sources */,
 				1A2A8CF61D5D36C500421E3E /* PromiseDelayTests.swift in Sources */,
 				1A7CC22F1DF4D37400929E7C /* PromiseEnsureTests.swift in Sources */,
+				00C2D985238F100500C42EF9 /* PromiseErrorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Promise.xcodeproj/project.pbxproj
+++ b/Promise.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 
 /* Begin PBXFileReference section */
 		00C2D984238F100500C42EF9 /* PromiseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseErrorTests.swift; sourceTree = "<group>"; };
+		00CB7C1A239864AE001AA965 /* main.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = main.yml; sourceTree = "<group>"; };
 		1A0073671E2865CC00EB319A /* ExecutionContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExecutionContextTests.swift; sourceTree = "<group>"; };
 		1A2A8CF51D5D36C500421E3E /* PromiseDelayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseDelayTests.swift; sourceTree = "<group>"; };
 		1A2A8CF71D5D58A800421E3E /* PromiseRaceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseRaceTests.swift; sourceTree = "<group>"; };
@@ -114,9 +115,26 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		00CB7C18239864AE001AA965 /* .github */ = {
+			isa = PBXGroup;
+			children = (
+				00CB7C19239864AE001AA965 /* workflows */,
+			);
+			path = .github;
+			sourceTree = "<group>";
+		};
+		00CB7C19239864AE001AA965 /* workflows */ = {
+			isa = PBXGroup;
+			children = (
+				00CB7C1A239864AE001AA965 /* main.yml */,
+			);
+			path = workflows;
+			sourceTree = "<group>";
+		};
 		3454F9C41D4FACD000985BBF = {
 			isa = PBXGroup;
 			children = (
+				00CB7C18239864AE001AA965 /* .github */,
 				76E25E381D8483D0000A58DF /* Promise.playground */,
 				3454F9D01D4FACD000985BBF /* Promise */,
 				3454F9DC1D4FACD000985BBF /* PromiseTests */,

--- a/Promise/Promise+Extras.swift
+++ b/Promise/Promise+Extras.swift
@@ -13,14 +13,6 @@ import Foundation
 
 struct PromiseCheckError: Error { }
 
-public struct GeneralError: Error {
-    public let message: String
-
-    public init(_ message: String) {
-        self.message = message
-    }
-}
-
 public enum Promises {
     /// Wait for all the promises you give it to fulfill, and once they have, fulfill itself
     /// with the array of all fulfilled values.
@@ -193,14 +185,6 @@ extension Promise {
                 onRejected(castedError)
             }
         })
-    }
-
-    public convenience init(errorMessage: String) {
-        self.init(error: GeneralError(errorMessage))
-    }
-    
-    public func reject(errorMessage: String) {
-        self.reject(GeneralError(errorMessage))
     }
 
     public func mapError(on queue: ExecutionContext = DispatchQueue.main, _ transformError: @escaping (Error) -> Error) -> Promise {

--- a/Promise/Promise+Extras.swift
+++ b/Promise/Promise+Extras.swift
@@ -13,6 +13,14 @@ import Foundation
 
 struct PromiseCheckError: Error { }
 
+public struct GeneralError: Error {
+    public let message: String
+
+    public init(_ message: String) {
+        self.message = message
+    }
+}
+
 public enum Promises {
     /// Wait for all the promises you give it to fulfill, and once they have, fulfill itself
     /// with the array of all fulfilled values.
@@ -184,6 +192,20 @@ extension Promise {
             if let castedError = error as? E {
                 onRejected(castedError)
             }
+        })
+    }
+
+    public convenience init(errorMessage: String) {
+        self.init(error: GeneralError(errorMessage))
+    }
+    
+    public func reject(errorMessage: String) {
+        self.reject(GeneralError(errorMessage))
+    }
+
+    public func mapError(on queue: ExecutionContext = DispatchQueue.main, _ transformError: @escaping (Error) -> Error) -> Promise {
+        return Promise(work: { (fulfill, reject) in
+            self.then(on: queue, fulfill, { reject(transformError($0)) })
         })
     }
 }

--- a/PromiseTests/PromiseErrorTests.swift
+++ b/PromiseTests/PromiseErrorTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Promise
+
+final class PromiseErrorTests: XCTestCase {
+    func testMapErrorChangesError() {
+        let p = Promise<Int>()
+        let e = expectation(description: "mapError")
+
+        var error: Error?
+        p.mapError { (e) -> Error in
+            return GeneralError("Changed")
+        }.catch { (caughtError) in
+            error = caughtError
+        }.always {
+            e.fulfill()
+        }
+
+        p.reject(GeneralError("Original"))
+
+        waitForExpectations(timeout: 1, handler: nil)
+
+        XCTAssertEqual((error as? GeneralError)?.message, "Changed")
+    }
+
+    func testRejectWithMessageRejectsPromise() {
+        let p = Promise<Void>()
+        let e = expectation(description: "reject with message")
+
+        var error: Error?
+        p.catch { (caughtError) in
+            error = caughtError
+        }.always {
+            e.fulfill()
+        }
+
+        p.reject(errorMessage: "some error")
+
+        waitForExpectations(timeout: 1, handler: nil)
+
+        XCTAssert(error is GeneralError)
+        XCTAssertEqual((error as? GeneralError)?.message, "some error")
+    }
+
+    func testErrorInitializer() {
+        let p = Promise<Void>(errorMessage: "some error")
+        let e = expectation(description: "error initializer")
+
+        var error: Error?
+        p.catch { (caughtError) in
+            error = caughtError
+        }.always {
+            e.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+
+        XCTAssert(error is GeneralError)
+        XCTAssertEqual((error as? GeneralError)?.message, "some error")
+    }
+}

--- a/PromiseTests/PromiseErrorTests.swift
+++ b/PromiseTests/PromiseErrorTests.swift
@@ -11,14 +11,48 @@ final class PromiseErrorTests: XCTestCase {
             return WrenchError(message: "Changed")
         }.catch(type: WrenchError.self) { caughtError in
             error = caughtError
-        }.always {
-            e.fulfill()
-        }
+        }.always(e.fulfill)
 
         p.reject(WrenchError(message: "Original"))
 
         waitForExpectations(timeout: 1, handler: nil)
 
         XCTAssertEqual(error?.message, "Changed")
+    }
+
+    func testTypedMapErrorChangesError() {
+        let p = Promise<Int>()
+        let e = expectation(description: "mapError")
+
+        var error: WrenchError?
+        p.mapError(type: PromiseCheckError.self) { (e) -> Error in
+            return WrenchError(message: "Changed")
+        }.catch(type: WrenchError.self) { caughtError in
+            error = caughtError
+        }.always(e.fulfill)
+
+        p.reject(PromiseCheckError())
+
+        waitForExpectations(timeout: 1, handler: nil)
+
+        XCTAssertEqual(error?.message, "Changed")
+    }
+
+    func testTypedMapErrorDoesntChangeErrorsOfUnspecifiedType() {
+        let p = Promise<Int>()
+        let e = expectation(description: "mapError")
+
+        var error: WrenchError?
+        p.mapError(type: PromiseCheckError.self) { (e) -> Error in
+            return WrenchError(message: "Changed")
+        }.catch(type: WrenchError.self) { caughtError in
+            error = caughtError
+        }.always(e.fulfill)
+
+        p.reject(WrenchError(message: "Original"))
+
+        waitForExpectations(timeout: 1, handler: nil)
+
+        XCTAssertEqual(error?.message, "Original")
     }
 }

--- a/PromiseTests/PromiseErrorTests.swift
+++ b/PromiseTests/PromiseErrorTests.swift
@@ -6,55 +6,19 @@ final class PromiseErrorTests: XCTestCase {
         let p = Promise<Int>()
         let e = expectation(description: "mapError")
 
-        var error: Error?
+        var error: WrenchError?
         p.mapError { (e) -> Error in
-            return GeneralError("Changed")
-        }.catch { (caughtError) in
+            return WrenchError(message: "Changed")
+        }.catch { (caughtError: WrenchError) in
             error = caughtError
         }.always {
             e.fulfill()
         }
 
-        p.reject(GeneralError("Original"))
+        p.reject(WrenchError(message: "Original"))
 
         waitForExpectations(timeout: 1, handler: nil)
 
-        XCTAssertEqual((error as? GeneralError)?.message, "Changed")
-    }
-
-    func testRejectWithMessageRejectsPromise() {
-        let p = Promise<Void>()
-        let e = expectation(description: "reject with message")
-
-        var error: Error?
-        p.catch { (caughtError) in
-            error = caughtError
-        }.always {
-            e.fulfill()
-        }
-
-        p.reject(errorMessage: "some error")
-
-        waitForExpectations(timeout: 1, handler: nil)
-
-        XCTAssert(error is GeneralError)
-        XCTAssertEqual((error as? GeneralError)?.message, "some error")
-    }
-
-    func testErrorInitializer() {
-        let p = Promise<Void>(errorMessage: "some error")
-        let e = expectation(description: "error initializer")
-
-        var error: Error?
-        p.catch { (caughtError) in
-            error = caughtError
-        }.always {
-            e.fulfill()
-        }
-
-        waitForExpectations(timeout: 1, handler: nil)
-
-        XCTAssert(error is GeneralError)
-        XCTAssertEqual((error as? GeneralError)?.message, "some error")
+        XCTAssertEqual(error.message, "Changed")
     }
 }

--- a/PromiseTests/PromiseErrorTests.swift
+++ b/PromiseTests/PromiseErrorTests.swift
@@ -9,7 +9,7 @@ final class PromiseErrorTests: XCTestCase {
         var error: WrenchError?
         p.mapError { (e) -> Error in
             return WrenchError(message: "Changed")
-        }.catch { (caughtError: WrenchError) in
+        }.catch(type: WrenchError.self) { caughtError in
             error = caughtError
         }.always {
             e.fulfill()
@@ -19,6 +19,6 @@ final class PromiseErrorTests: XCTestCase {
 
         waitForExpectations(timeout: 1, handler: nil)
 
-        XCTAssertEqual(error.message, "Changed")
+        XCTAssertEqual(error?.message, "Changed")
     }
 }

--- a/PromiseTests/PromiseErrorTests.swift
+++ b/PromiseTests/PromiseErrorTests.swift
@@ -55,4 +55,10 @@ final class PromiseErrorTests: XCTestCase {
 
         XCTAssertEqual(error?.message, "Original")
     }
+
+    static let allTests = [
+        ("testMapErrorChangesError", testMapErrorChangesError),
+        ("testTypedMapErrorChangesError", testTypedMapErrorChangesError),
+        ("testTypedMapErrorDoesntChangeErrorsOfUnspecifiedType", testTypedMapErrorDoesntChangeErrorsOfUnspecifiedType),
+        ]
 }

--- a/PromiseTests/PromiseErrorTests.swift
+++ b/PromiseTests/PromiseErrorTests.swift
@@ -11,7 +11,9 @@ final class PromiseErrorTests: XCTestCase {
             return WrenchError(message: "Changed")
         }.catch(type: WrenchError.self) { caughtError in
             error = caughtError
-        }.always(e.fulfill)
+        }.always{
+            e.fulfill()
+        }
 
         p.reject(WrenchError(message: "Original"))
 
@@ -29,7 +31,9 @@ final class PromiseErrorTests: XCTestCase {
             return WrenchError(message: "Changed")
         }.catch(type: WrenchError.self) { caughtError in
             error = caughtError
-        }.always(e.fulfill)
+        }.always{
+            e.fulfill()
+        }
 
         p.reject(PromiseCheckError())
 
@@ -47,7 +51,9 @@ final class PromiseErrorTests: XCTestCase {
             return WrenchError(message: "Changed")
         }.catch(type: WrenchError.self) { caughtError in
             error = caughtError
-        }.always(e.fulfill)
+        }.always{
+            e.fulfill()
+        }
 
         p.reject(WrenchError(message: "Original"))
 


### PR DESCRIPTION
These are some of the additions we've made in our private copy of this library that allow for transforming an error if needed, that add convenient ways to reject or construct a rejected promise, and that adds a `GeneralError` type to assist with those new ways to reject a promise.