### PR TITLE
Requiring app extension api only for Promise-scheme

### DIFF
--- a/Promise.xcodeproj/project.pbxproj
+++ b/Promise.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 		3454F9E31D4FACD000985BBF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
@@ -613,6 +614,7 @@
 		3454F9E41D4FACD000985BBF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
This commit fixes #66

I don't think this will have any other impact then removing warnings when using the framework in an app extension.