### PR TITLE
Added shouldRetry parameter to retry to allow for conditional retrying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+*.DS_Store


### PR DESCRIPTION
I've come across the need for conditional retrying (I.e., retrying only under certain error conditions). This PR adds an optional parameter to the `retry` method to allow for custom logic to be inserted into the decision making logic for retrying.

Example use: 

```swift
let shouldRetryHandler: ((Error) -> Bool) = { error in
    guard let locationError = error as? CLError, locationError.code == CLError.locationUnknown else {
        return false
    }
    return true
}

Promises.retry(count: 3, delay: 2, shouldRetry: shouldRetryHandler) {
    locationManager.requestCurrentLocation()
}
.then(...)
.catch(...)
```