### PR TITLE
Always use given queue when handling recover block

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   mac:
     name: Mac
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
     steps:
     - name: Checkout
       uses: actions/checkout@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Make directory
       run: mkdir tests
     - name: Download and Install Swift
-      run: curl https://swift.org/builds/swift-5.0.2-release/ubuntu1804/swift-5.0.2-RELEASE/swift-5.0.2-RELEASE-ubuntu18.04.tar.gz -s | tar xz -C tests &> /dev/null
+      run: curl https://swift.org/builds/swift-5.0.2-release/ubuntu1804/swift-5.0.2-RELEASE/swift-5.0.2-RELEASE-ubuntu18.04.tar.gz -s -L | tar xz -C tests &> /dev/null
     - name: Update apt
       run: sudo apt-get update
     - name: Install clang and libicu

--- a/Promise/Promise+Extras.swift
+++ b/Promise/Promise+Extras.swift
@@ -233,14 +233,14 @@ extension Promise {
     /// - Returns: A discardable instance of this promise that can be used for further chaining.
     public func recover<E: Error>(type errorType: E.Type, on queue: ExecutionContext = DispatchQueue.main, _ recovery: @escaping (E) throws -> Promise<Value>) -> Promise<Value> {
         return Promise(work: { fulfill, reject in
-            self.then(fulfill).catch(on: queue, { anyError in
+            self.then(on: queue, fulfill).catch(on: queue, { anyError in
                 guard let error = anyError as? E else {
                     reject(anyError)
                     return
                 }
 
                 do {
-                    try recovery(error).then(fulfill, reject)
+                    try recovery(error).then(on: queue, fulfill, reject)
                 } catch (let error) {
                     reject(error)
                 }


### PR DESCRIPTION
While handling `recover`, the library is calling `then` a couple times without specifying a queue so it uses the default (main) queue. But on Vapor the main queue is blocked, so the `then` callback is never invoked. This can be fixed by always using the queue that was passed to `recover`.
